### PR TITLE
Swap to msportals.io

### DIFF
--- a/.github/ISSUE_TEMPLATE/add_missing_portal.md
+++ b/.github/ISSUE_TEMPLATE/add_missing_portal.md
@@ -12,7 +12,7 @@ What is the portal you are looking for called?
 
 **Portal URL**
 What is the main URL/Site we are missing
-Example: https://github.com/adamfowlerit/msportals.xyz/search?q=admin.teams.microsoft.com
+Example: https://github.com/adamfowlerit/msportals.io/search?q=admin.teams.microsoft.com
 
 **Secondary Portal URLs**
 We try to add aka.ms links wherever we can. Do you know of a related aka.ms link for your suggestion?
@@ -21,14 +21,14 @@ Example: https://aka.ms/teamsadmincenter
 **What portal page and section would this fit best on?**
 We are currently making our web-pages from JSON files, which page and section does this fit best with?
 
-[All JSON Source Files](https://github.com/adamfowlerit/msportals.xyz/blob/master/_data/portals)
+[All JSON Source Files](https://github.com/adamfowlerit/msportals.io/blob/master/_data/portals)
 
 | Website Page                                              | JSON Source                                            |
 |---------------------------------------------------------- |------------------------------------------------------- |
-| [Home page / Admin Links](https://msportals.xyz/)         | [Home page / Admin JSON](./_data/portals/admin.json)  |
-| [3rd Party Links](https://msportals.xyz/3rdparty)         | [3rd Party JSON](./_data/portals/thirdparty.json)     |
-| [US Government Links](https://msportals.xyz/usgovt)       | [US Government JSON](./_data/portals/us-govt.json)  |
-| [End User Links/Apps](https://msportals.xyz/userportals)  | [End User JSON](./_data/portals/user.json)     |
+| [Home page / Admin Links](https://msportals.io/)         | [Home page / Admin JSON](./_data/portals/admin.json)  |
+| [3rd Party Links](https://msportals.io/3rdparty)         | [3rd Party JSON](./_data/portals/thirdparty.json)     |
+| [US Government Links](https://msportals.io/usgovt)       | [US Government JSON](./_data/portals/us-govt.json)  |
+| [End User Links/Apps](https://msportals.io/userportals)  | [End User JSON](./_data/portals/user.json)     |
 
 **Special Notes**
 On some of the portals, we have been adding notes. For example

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,4 +8,4 @@ contact_links:
     about: If you would rather chat with other IT Professionals, you might prefer this community
   - name: "Official Support Channels"
     url: http://support.microsoft.com/
-    about: All resources in this repo, msportals.xyz, and the Discord Communities linked above are completely volunteer based and not official support channels. If you need official support for something or want to "Open a ticket with Microsoft" then you can check with your IT Administrator or this page should help you find the correct area. 
+    about: All resources in this repo, msportals.io, and the Discord Communities linked above are completely volunteer based and not official support channels. If you need official support for something or want to "Open a ticket with Microsoft" then you can check with your IT Administrator or this page should help you find the correct area. 

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-msportals.xyz
+msportals.io

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# msportals.xyz - Microsoft Portals
+# msportals.io - Microsoft Portals
 
 Microsoft has a **lot** of portals.
 
-After not remembering all the Microsoft Portal URLs so many times, Adam decided to make a list and with a help from a few others, have gotten to this stage. You can read more about the details on the [About page](https://github.com/adamfowlerit/msportals.xyz/blob/master/about.md)
+After not remembering all the Microsoft Portal URLs so many times, Adam decided to make a list and with a help from a few others, have gotten to this stage. You can read more about the details on the [About page](https://github.com/adamfowlerit/msportals.io/blob/master/about.md)
 
 # Contributing #
-This project welcomes all pull requests and submissions! If you are seeing this elsewhere, you can contribute to the project at [this Github Repo](https://github.com/adamfowlerit/msportals.xyz). The website at [msportals.xyz](msportals.xyz) is hosted through GitHub Pages, and the portal links are currently built from JSON files. You can see more information about those [here](https://github.com/adamfowlerit/msportals.xyz/tree/master/_data/portals). 
+This project welcomes all pull requests and submissions! If you are seeing this elsewhere, you can contribute to the project at [this Github Repo](https://github.com/adamfowlerit/msportals.io). The website at [msportals.io](msportals.io) is hosted through GitHub Pages, and the portal links are currently built from JSON files. You can see more information about those [here](https://github.com/adamfowlerit/msportals.io/tree/master/_data/portals). 
 
-If you don't want to make a Pull Request, but still have feedback, you can open an [Issue](https://github.com/adamfowlerit/msportals.xyz/issues)
+If you don't want to make a Pull Request, but still have feedback, you can open an [Issue](https://github.com/adamfowlerit/msportals.io/issues)

--- a/_data/portals/readme.md
+++ b/_data/portals/readme.md
@@ -6,10 +6,10 @@ We are currently making our web-pages from JSON files, our current JSON Portal s
 
 | Website Page                                              | JSON Source                                            |
 |---------------------------------------------------------- |------------------------------------------------------- |
-| [Home page / Admin Links](https://msportals.xyz/)         | [Home page / Admin JSON](./_data/portals/admin.json)   |
-| [3rd Party Links](https://msportals.xyz/3rdparty)         | [3rd Party JSON](./_data/portals/thirdparty.json)      |
-| [US Government Links](https://msportals.xyz/usgovt)       | [US Government JSON](./_data/portals/us-govt.json)     |
-| [End User Links/Apps](https://msportals.xyz/userportals)  | [End User JSON](./_data/portals/user.json)             |
+| [Home page / Admin Links](https://msportals.io/)         | [Home page / Admin JSON](./_data/portals/admin.json)   |
+| [3rd Party Links](https://msportals.io/3rdparty)         | [3rd Party JSON](./_data/portals/thirdparty.json)      |
+| [US Government Links](https://msportals.io/usgovt)       | [US Government JSON](./_data/portals/us-govt.json)     |
+| [End User Links/Apps](https://msportals.io/userportals)  | [End User JSON](./_data/portals/user.json)             |
 
 ## Fields ##
 
@@ -52,4 +52,4 @@ Example: The new versus old Exchange Portals shown below.
 
 ## Additional context ##
 
-Suggestions or context for the portals? If you are not certain about how to configure this, you may wish to create a [New Issue](https://github.com/adamfowlerit/msportals.xyz/issues/new/choose) instead.
+Suggestions or context for the portals? If you are not certain about how to configure this, you may wish to create a [New Issue](https://github.com/adamfowlerit/msportals.io/issues/new/choose) instead.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     <link rel="icon" type="image/png" href="/images/O365_Admin_Green.png"/>
     <script src="/assets/js/favorites.js"></script>
-    <meta property="og:image:url" content="https://msportals.xyz/images/O365_Admin_Green.png" />
+    <meta property="og:image:url" content="https://msportals.io/images/O365_Admin_Green.png" />
     <meta property="og:image:width" content="400px" />
     <meta property="og:image:height" content="400px" />
 
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Microsoft Portals Site" />
     <meta name="twitter:description" content="An aggregation of all of the Microsoft Portals we could find." />
-    <meta name="twitter:image" content="https://msportals.xyz/images/O365_Admin_Green.png" />
+    <meta name="twitter:image" content="https://msportals.io/images/O365_Admin_Green.png" />
 
 {% seo %}
   </head>

--- a/about.md
+++ b/about.md
@@ -4,7 +4,7 @@ title: About
 permalink: /about/
 ---
 
-This site is pretty new at this stage, and we're working on improving things. If you have feedback or found a site we don't have listed, visit our [GitHub page](https://github.com/adamfowlerit/msportals.xyz) and let us know there.
+This site is pretty new at this stage, and we're working on improving things. If you have feedback or found a site we don't have listed, visit our [GitHub page](https://github.com/adamfowlerit/msportals.io) and let us know there.
 
 ## Q & A
 


### PR DESCRIPTION
Swap over to msportals.io for all references, including the CNAME for the Github Pages to pull from.
The Repo also needs to be renamed from msportals.xyz to msportals.io for this

First need to setup the A/CNAME records for msportals.io, then rename the repo, and then commit these changes (otherwise the deployment will fail, or the public links won't work)