### PR TITLE
Microsoft 365 Network Insights

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -40,7 +40,8 @@
       },
       {
         "portalName": "Microsoft 365 Network Insights",
-        "primaryURL": "https://portal.office.com/adminportal/home#/networkperformance"
+        "primaryURL": "https://portal.office.com/adminportal/home#/networkperformance",
+        "note": "Preview"
       },
       {
         "portalName": "Microsoft Call Quality Dashboard",

--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -39,6 +39,10 @@
         "primaryURL": "https://connectivity.office.com"
       },
       {
+        "portalName": "Microsoft 365 Network Insights",
+        "primaryURL": "https://portal.office.com/adminportal/home#/networkperformance"
+      },
+      {
         "portalName": "Microsoft Call Quality Dashboard",
         "primaryURL": "https://cqd.teams.microsoft.com"
       },


### PR DESCRIPTION
Added link to the "Microsoft 365 Network Insights" (also called the "Microsoft 365 network connectivity") section of the Microsoft 365 admin center which is otherwise inaccessible.   Documentation on this portal and it's purpose is available [here](https://docs.microsoft.com/en-us/microsoft-365/enterprise/office-365-network-mac-perf-insights?view=o365-worldwide).   