### PR TITLE
Alanjmcf patch mileiq 2

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -121,10 +121,6 @@
         "primaryURL": "https://portal.rooms.microsoft.com/"
       },
       {
-        "portalName": "MileIQ Admin Center",
-        "primaryURL": "https://admin.mileiq.com"
-      },
-      {
         "portalName": "My Staff (preview)",
         "primaryURL": "https://mystaff.microsoft.com",
         "secondaryURLs": [

--- a/_data/portals/user.json
+++ b/_data/portals/user.json
@@ -43,10 +43,6 @@
         "primaryURL": "https://web.kaiza.la"
       },
       {
-        "portalName": "MileIQ",
-        "primaryURL": "https://dashboard.mileiq.com"
-      },
-      {
         "portalName": "MyAnalytics",
         "primaryURL": "https://myanalytics.microsoft.com"
       },


### PR DESCRIPTION
MileIQ has been sold by Microsoft. Remove portals I assume?

  https://en.wikipedia.org/wiki/MileIQ
  I added these previously.
  Remove admin+user I assume as now no longer part of MSFT?  Or move to third-party??