### PR TITLE
Re-organised location of some links.

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -20,12 +20,6 @@
           }
         ]
       },
-	{
-        "portalName": "Microsoft 365 Defender",
-        "primaryURL": "https://security.microsoft.com",
-	"note": "Previously Microsoft 365 security"
-		
-      },
       {
         "portalName": "Apps Admin Center",
         "primaryURL": "https://config.office.com"
@@ -264,11 +258,6 @@
         "portalName": "Azure Backup Center",
         "primaryURL": "https://portal.azure.com/#blade/Microsoft_Azure_DataProtection/BackupCenterMenuBlade/overview"
       },
-      {
-        "portalName": "Microsoft Defender for Cloud (MDC)",
-        "primaryURL": "https://portal.azure.com/#blade/Microsoft_Azure_Security/SecurityMenuBlade/0",
-	"note": "Azure Security Center"
-      },
 	{
         "portalName": "Privileged Identity Management",
         "primaryURL": "https://portal.azure.com/#blade/Microsoft_Azure_PIMCommon/CommonMenuBlade/quickStart",
@@ -382,18 +371,12 @@
     ]
   },
   {
-    "groupName": "Security / Defender IT Admin Portals",
-    "portals": [
+    "groupName": "Microsoft Defender / Security IT Admin Portals",
+    "portals": [	
 	{
-        "portalName": "Attack simulation training",
-        "primaryURL": "https://security.microsoft.com/attacksimulator",
-        "secondaryURLs": [
-          {
-            "icon": "aka.ms",
-            "url": "https://aka.ms/AttackSim"
-          }
-        ],
-        "note": "sub-portal"
+        "portalName": "Microsoft 365 Defender",
+        "primaryURL": "https://security.microsoft.com",
+	"note": "Previously Microsoft 365 security"	
       },
       {
         "portalName": "Microsoft Defender for Cloud Apps (MDCA)",
@@ -431,6 +414,22 @@
 	{
         "portalName": "Microsoft Defender ATP Testground",
         "primaryURL": "https://demo.wd.microsoft.com/"
+      },
+	    {
+        "portalName": "Attack simulation training",
+        "primaryURL": "https://security.microsoft.com/attacksimulator",
+        "secondaryURLs": [
+          {
+            "icon": "aka.ms",
+            "url": "https://aka.ms/AttackSim"
+          }
+        ],
+        "note": "sub-portal"
+      },
+      {
+        "portalName": "Microsoft Defender for Cloud (MDC)",
+        "primaryURL": "https://portal.azure.com/#blade/Microsoft_Azure_Security/SecurityMenuBlade/0",
+	"note": "Azure Security Center (ASC)"
       },
       {
         "portalName": "Microsoft Secure Score",


### PR DESCRIPTION
moved Defender for Cloud in with Microsoft Defender portals (even though its technically part of Azure)