### PR TITLE
Add Visual Studio (VS) Code in the Web

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -547,7 +547,7 @@
       },
       {
         "portalName": "Visual Studio (VS) Code in the Web",
-        "primaryURL": "https://insiders.vscode.dev/"
+        "primaryURL": "https://insiders.vscode.dev/",
         "note": "Insiders Version"
       },
       {

--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -542,6 +542,15 @@
         "primaryURL": "https://mgt.dev/"
       },
       {
+        "portalName": "Visual Studio (VS) Code in the Web",
+        "primaryURL": "https://www.vscode.dev/"
+      },
+      {
+        "portalName": "Visual Studio (VS) Code in the Web",
+        "primaryURL": "https://insiders.vscode.dev/"
+        "note": "Insiders Version"
+      },
+      {
         "portalName": "Microsoft Online Error Code Lookup",
         "primaryURL": "https://login.microsoftonline.com/error"
       },      {


### PR DESCRIPTION
Add Visual Studio (VS) Code in the Web (https://www.vscode.dev/) and Visual Studio (VS) Code in the Web - Insiders Version (https://insiders.vscode.dev/)

https://code.visualstudio.com/blogs/2021/10/20/vscode-dev