### PR TITLE
Add Microsoft Entra

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -496,6 +496,10 @@
       {
         "portalName": "Submit Abuse Report (CERT)",
         "primaryURL": "https://msrc.microsoft.com/report/abuse"
+      },
+      {
+        "portalName": "Microsoft Entra",
+        "primaryURL": "https://entra.microsoft.com"
       }
     ]
   },


### PR DESCRIPTION
Added URL for MS Entra 

There is currently an [aka.ms/entra](https://aka.ms/enta) however at present it links to the docs.

MS announcement blog post [here](https://www.microsoft.com/security/blog/2022/05/31/secure-access-for-a-connected-worldmeet-microsoft-entra/)