### PR TITLE
Add ?tenant_id= support for B2B links

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -67,6 +67,10 @@
           {
             "icon": "aka.ms",
             "url": "https://aka.ms/memac"
+          },
+          {
+            "icon": "B2B",
+            "url": "https://endpoint.microsoft.com/{tenant_id}"
           }
         ],
         "note": "Intune"
@@ -212,7 +216,13 @@
       },
       {
         "portalName": "My Access (Access Packages)",
-        "primaryURL": "https://myaccess.microsoft.com/"
+        "primaryURL": "https://myaccess.microsoft.com/",
+        "secondaryURLs": [
+          {
+            "icon": "B2B",
+            "url": "https://myaccess.microsoft.com/{tenant_id}"
+          }
+        ]
       }
     ]
   },
@@ -227,6 +237,10 @@
           {
             "icon": "aka.ms",
             "url": "https://aka.ms/AzPortal"
+          },
+          {
+            "icon": "B2B",
+            "url": "https://portal.azure.com/{tenant_id}/"
           }
         ]
       },
@@ -321,7 +335,7 @@
       {
         "portalName": "Users - Active users",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/users"
-      },  
+      },
       {
         "portalName": "Users - Contacts",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/Contact"
@@ -333,11 +347,11 @@
       {
         "portalName": "Users - Deleted users",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/deletedusers"
-      },    
+      },
       {
         "portalName": "Teams & groups - Active teams and groups",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/groups"
-      },   
+      },
       {
         "portalName": "Teams & groups - Deleted groups",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/deletedgroups"
@@ -398,7 +412,7 @@
         "portalName": "Settings - Domains",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/Domains"
       },
-       {
+      {
         "portalName": "Settings - Search & intelligence",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/MicrosoftSearch"
       },
@@ -410,15 +424,15 @@
         "portalName": "Settings - Integrated apps",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/Settings/IntegratedApps"
       },
-       {
+      {
         "portalName": "Settings - Partner relationships",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/partners"
       },
-       {
+      {
         "portalName": "Setup",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/featureexplorer"
       },
-       {
+      {
         "portalName": "Reports - Adoption Score",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/adoptionscore"
       },
@@ -426,15 +440,15 @@
         "portalName": "Reports - Usage",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/reportsUsage"
       },
-       {
+      {
         "portalName": "Health - Dashboard",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/healthoverview"
       },
-       {
+      {
         "portalName": "Health - Service health",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/servicehealth"
       },
-       {
+      {
         "portalName": "Health - Message center",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/MessageCenter"
       },
@@ -450,8 +464,8 @@
         "portalName": "Health - Software updates",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/softwareupdates"
       }
-  ]
-},
+    ]
+  },
   {
     "groupName": "Azure AI / ML Portals",
     "portals": [
@@ -554,6 +568,12 @@
       {
         "portalName": "Microsoft 365 Defender",
         "primaryURL": "https://security.microsoft.com",
+        "secondaryURLs": [
+          {
+            "icon": "B2B",
+            "url": "https://security.microsoft.com/homepage?tid={tenant_id}"
+          }
+        ],
         "note": "Previously Microsoft 365 security"
       },
       {
@@ -589,7 +609,7 @@
         ],
         "note": "Deprecated: Previously Azure ATP"
       },
-            {
+      {
         "portalName": "Microsoft Defender for Internet of Things (IoT)",
         "primaryURL": "https://portal.azure.com/#blade/Microsoft_Azure_IoT_Defender/IoTDefenderDashboard"
       },
@@ -621,7 +641,7 @@
       {
         "portalName": "Microsoft Entra admin center",
         "primaryURL": "https://entra.microsoft.com",
-      "note": "Identity Management"
+        "note": "Identity Management"
       },
       {
         "portalName": "Microsoft Secure Score",
@@ -716,6 +736,10 @@
           {
             "icon": "aka.ms",
             "url": "https://aka.ms/GE"
+          },
+          {
+            "icon": "B2B",
+            "url": "https://developer.microsoft.com/en-us/graph/graph-explorer?tenant={tenant_id}"
           }
         ]
       },
@@ -806,17 +830,17 @@
       }
     ]
   },
-   {
+  {
     "groupName": "Microsoft Trials",
-    "portals": [ 
-       {
+    "portals": [
+      {
         "portalName": "Microsoft Defender for Identity Trial -3-month",
         "primaryURL": "https://signup.microsoft.com/Signup?OfferId=a0db242a-96d7-4f99-bd52-05c0d5556257&ali=1"
-      },  
+      },
       {
         "portalName": "Microsoft Defender for Office 365 (Plan 2) 90 Day, Full Tenant Trial",
         "primaryURL": "https://signup.microsoft.com/signup/logout?OfferId=20298c4d-d500-47fa-b3cd-a3f7d75d9253"
-      }, 
+      },
       {
         "portalName": "Microsoft Defender for Endpoint P2 Trial - 3-month",
         "primaryURL": "https://signup.microsoft.com/create-account/signup?products=7f379fee-c4f9-4278-b0a1-e4c8c2fcdf7e&ru=https://aka.ms/MDEp2OpenTrial"
@@ -857,15 +881,15 @@
         "portalName": "Compliance Manager Premium Assessment Add-On Trial - 90-day",
         "primaryURL": "https://signup.microsoft.com/get-started/signup?products=e320704d-b7c9-4012-b6a6-0a2679790360&culture=en-us&country=US&ali=1"
       },
-       {
+      {
         "portalName": "Microsoft 365 E5 eDiscovery and Audit Trial",
         "primaryURL": "https://signup.microsoft.com/signup?OfferId=c6ca396f-4467-4761-95f6-b6d9a5386716"
       },
-       {
+      {
         "portalName": "Privacy Management - subject rights request (50) Trial - 90-day",
         "primaryURL": "https://signup.microsoft.com/get-started/signup?products=1c6c565d-cae2-4648-aa92-bf52b523fdbd&ali=1"
       },
-       {
+      {
         "portalName": "Priva Privacy Risk Management Trial - 90-day",
         "primaryURL": "https://signup.microsoft.com/get-started/signup?products=e6b633e0-1b1e-4d95-b414-3ce9e8023c39"
       },
@@ -873,15 +897,15 @@
         "portalName": "Sign-up for Office 365 E3, 25 licenses trial, 30-day",
         "primaryURL": "https://signup.microsoft.com/get-started/signup?OfferId=B07A1127-DE83-4a6d-9F85-2C104BDAE8B4&dl=ENTERPRISEPACK&ali=1&products=cfq7ttc0k59j%3a0009&bac=1"
       },
-       {
+      {
         "portalName": "Sign-up for Azure $200 US Credits in 3 months, 12 months free services trial",
         "primaryURL": "https://azure.microsoft.com/en-us/offers/ms-azr-0044p/"
       },
-       {
+      {
         "portalName": "Sign-up for Dynamics 365 for 30 days trial",
         "primaryURL": "https://trials.dynamics.com"
       },
-       {
+      {
         "portalName": "Sign-up for Microsoft 365 Developer Program trial",
         "primaryURL": "https://developer.microsoft.com/en-us/microsoft-365/dev-program"
       },
@@ -889,8 +913,8 @@
         "portalName": "Sign-up for Intune, 1-month trial",
         "primaryURL": "https://go.microsoft.com/fwlink/?linkid=2019088"
       }
-      ]
-      },
+    ]
+  },
   {
     "groupName": "Other Useful Microsoft Portals",
     "portals": [
@@ -953,7 +977,7 @@
         "portalName": "Microsoft Exam Sandbox",
         "primaryURL": "https://mscertdemo.starttest.com/"
       },
-       {
+      {
         "portalName": "Microsoft Events",
         "primaryURL": "https://events.microsoft.com"
       },
@@ -1058,7 +1082,7 @@
         "portalName": "Azure Updates",
         "primaryURL": "https://azure.microsoft.com/en-us/updates/"
       },
-        {
+      {
         "portalName": "Microsoft Unlocked",
         "primaryURL": "https://unlocked.microsoft.com/"
       },

--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -405,7 +405,7 @@
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/support/requests"
       },
       {
-        "portalName": "Support - Microsoftt hardware support",
+        "portalName": "Support - Microsoft hardware support",
         "primaryURL": "https://admin.microsoft.com/Adminportal/Home#/support/microsofthardwaresupport"
       },
       {

--- a/_data/portals/user.json
+++ b/_data/portals/user.json
@@ -242,6 +242,10 @@
           {
             "url": "https://myprofile.microsoft.com",
             "icon": "Alt 🔗 2"
+          },
+          {
+            "icon": "B2B",
+            "url": "https://myaccount.microsoft.com/?tenantId={tenant_id}"
           }
         ]
       },

--- a/_data/portals/user.json
+++ b/_data/portals/user.json
@@ -18,7 +18,7 @@
         "portalName": "Cortana",
         "primaryURL": "https://cortana.office.com"
       },
-            {
+      {
         "portalName": "Customer Voice",
         "primaryURL": "https://customervoice.microsoft.com/"
       },
@@ -105,7 +105,13 @@
       },
       {
         "portalName": "Teams",
-        "primaryURL": "https://teams.microsoft.com"
+        "primaryURL": "https://teams.microsoft.com",
+        "secondaryURLs": [
+          {
+            "icon": "B2B",
+            "url": "https://teams.microsoft.com/_?tenantId={tenant_id}"
+          }
+        ]
       },
       {
         "portalName": "To-Do",
@@ -153,7 +159,7 @@
       {
         "portalName": "Bing Image Creator",
         "primaryURL": "https://www.bing.com/create"
-      },     
+      },
       {
         "portalName": "Change Password",
         "primaryURL": "https://account.activedirectory.windowsazure.com/ChangePassword.aspx"
@@ -166,26 +172,26 @@
         "portalName": "Cloud Voicemail",
         "primaryURL": "https://admin1a.online.lync.com/lscp/usp/voicemail/"
       },
-        {
-          "portalName": "Device Login - Work or School Account",
-          "primaryURL": "https://microsoft.com/devicelogin",
-          "secondaryURLs": [
-            {
-              "icon": "aka.ms",
-              "url": "https://aka.ms/devicelogin"
-            }
-          ]
-        },
-        {
-          "portalName": "Device Login - Microsoft account or MSA (Personal Account)",
-          "primaryURL": "https://microsoft.com/link",
-          "secondaryURLs": [
-            {
-              "icon": "aka.ms",
-              "url": "https://aka.ms/remoteconnect"
-            }
-          ]
-        },
+      {
+        "portalName": "Device Login - Work or School Account",
+        "primaryURL": "https://microsoft.com/devicelogin",
+        "secondaryURLs": [
+          {
+            "icon": "aka.ms",
+            "url": "https://aka.ms/devicelogin"
+          }
+        ]
+      },
+      {
+        "portalName": "Device Login - Microsoft account or MSA (Personal Account)",
+        "primaryURL": "https://microsoft.com/link",
+        "secondaryURLs": [
+          {
+            "icon": "aka.ms",
+            "url": "https://aka.ms/remoteconnect"
+          }
+        ]
+      },
       {
         "portalName": "Exchange Control Panel (Personal)",
         "primaryURL": "https://outlook.office.com/ecp/"
@@ -265,7 +271,13 @@
       },
       {
         "portalName": "My Sign-Ins",
-        "primaryURL": "https://mysignins.microsoft.com"
+        "primaryURL": "https://mysignins.microsoft.com",
+        "secondaryURLs": [
+          {
+            "icon": "B2B",
+            "url": "https://mysignins.microsoft.com/security-info?tenant={tenant_id}"
+          }
+        ]
       },
       {
         "portalName": "My Staff",
@@ -293,7 +305,7 @@
         "portalName": "Self Service Password Reset Setup",
         "primaryURL": "https://account.activedirectory.windowsazure.com/PasswordReset/Register.aspx?regref=ssprsetup"
       },
-            {
+      {
         "portalName": "Windows Virtual Desktop Web Client (ARM)",
         "primaryURL": "https://rdweb.wvd.microsoft.com/arm/webclient"
       },

--- a/_includes/portal.html
+++ b/_includes/portal.html
@@ -18,8 +18,8 @@
             </span>
             {% if portal.secondaryURLs %}
             <span class="portal-secondary-urls">
-                &ensp;• {% for secondary in portal.secondaryURLs %}<a class="btn-aka-ms btn" href="{{secondary.url}}"
-                    target="_blank">{{secondary.icon}}</a>&thinsp;{% endfor %}
+                &ensp;• {% for secondary in portal.secondaryURLs %}<a class="btn-{{secondary.icon}} btn-secondary btn"
+                    href="{{secondary.url}}" target="_blank">{{secondary.icon}}</a>&thinsp;{% endfor %}
             </span>
             {% endif %}
         </div>

--- a/_includes/tenantid.html
+++ b/_includes/tenantid.html
@@ -3,6 +3,12 @@
     <input id="tenant_id" name="tenant_id" class="quickfilter" type="text" placeholder="B2B Tenant ID" />
 </form>
 
+<div id="tenant_id_privacy_warning" style="display:none">
+    <strong>Privacy Note:</strong> You can save the current page as
+    a bookmark to store
+    the tenant ID, but the tenant ID will show up in logs.
+</div>
+
 <script type="text/javascript">
 
     function replaceTenantId() {
@@ -13,9 +19,11 @@
             tenant_id = "00000000-0000-0000-0000-000000000000";
             theURL.search = window.location.search.substring(1);
             theURL.searchParams.delete("tenant_id");
+            document.querySelector("#tenant_id_privacy_warning").style = "display:none";
         } else {
             theURL.search = window.location.search.substring(1);
             theURL.searchParams.set("tenant_id", this.value);
+            document.querySelector("#tenant_id_privacy_warning").style = "";
         }
 
         const links = document.getElementsByClassName("btn-B2B");

--- a/_includes/tenantid.html
+++ b/_includes/tenantid.html
@@ -1,0 +1,53 @@
+<!-- <form style="margin: 0; padding: 0; display: inline">
+    <label for="tenant_id" style="display: none">B2B Tenant ID:</label>
+    <input id="tenant_id" name="tenant_id" class="quickfilter" type="text" placeholder="B2B Tenant ID" />
+</form> -->
+
+<script type="text/javascript">
+    function getHashParams() {
+        /**
+         * Get the page hash parameters
+         * @return {Object} a dict of key=value pairs from location.hash
+         */
+        let params = {};
+
+        let vars = location.hash.substring(1).split('&');
+        for (let i = 0; i < vars.length; i++) {
+            let kv = vars[i].split('=');
+            params[kv[0]] = kv[1];
+        }
+
+        return params;
+    }
+
+    function replaceTenantId(tenant_id) {
+        const links = document.getElementsByClassName("btn-B2B");
+        for (let i = 0; i < links.length; i++) {
+            // Replace twice, because URL components are escaped, whereas query components aren't
+            links[i].href = links[i].href.replace("{tenant_id}", tenant_id).replace("%7Btenant_id%7D", tenant_id);
+        }
+    }
+
+    window.addEventListener("DOMContentLoaded", function () {
+
+        // const params = getHashParams();
+        // if ("tenant_id" in params) {
+        //     const tenant_id = params["tenant_id"];
+        // }
+
+        let theURL = new URL("https://dummy.com");
+        theURL.search = window.location.search.substring(1);
+        const tenant_id = theURL.searchParams.get("tenant_id");
+
+        replaceTenantId(tenant_id);
+
+        // const tenantInput = document.querySelector("#tenant_id");
+        // tenantInput.value = tenant_id;
+        // // Add Event Listeners for changes (After we set the initial value)
+        // tenantInput.addEventListener("change", showOnlyMatchedPortals);
+        // tenantInput.addEventListener("keyup", showOnlyMatchedPortals);
+        // tenantInput.focus({
+        //     preventScroll: true,
+        // });
+    }, false);
+</script>

--- a/_includes/tenantid.html
+++ b/_includes/tenantid.html
@@ -1,53 +1,62 @@
-<!-- <form style="margin: 0; padding: 0; display: inline">
+<form style="margin: 0; padding: 0; display: inline">
     <label for="tenant_id" style="display: none">B2B Tenant ID:</label>
     <input id="tenant_id" name="tenant_id" class="quickfilter" type="text" placeholder="B2B Tenant ID" />
-</form> -->
+</form>
 
 <script type="text/javascript">
-    function getHashParams() {
-        /**
-         * Get the page hash parameters
-         * @return {Object} a dict of key=value pairs from location.hash
-         */
-        let params = {};
 
-        let vars = location.hash.substring(1).split('&');
-        for (let i = 0; i < vars.length; i++) {
-            let kv = vars[i].split('=');
-            params[kv[0]] = kv[1];
+    function replaceTenantId() {
+        let tenant_id = document.querySelector("#tenant_id").value;
+        let theURL = new URL(window.location.toString());
+
+        if (tenant_id == "") {
+            tenant_id = "00000000-0000-0000-0000-000000000000";
+            theURL.search = window.location.search.substring(1);
+            theURL.searchParams.delete("tenant_id");
+        } else {
+            theURL.search = window.location.search.substring(1);
+            theURL.searchParams.set("tenant_id", this.value);
         }
 
-        return params;
-    }
-
-    function replaceTenantId(tenant_id) {
         const links = document.getElementsByClassName("btn-B2B");
         for (let i = 0; i < links.length; i++) {
             // Replace twice, because URL components are escaped, whereas query components aren't
-            links[i].href = links[i].href.replace("{tenant_id}", tenant_id).replace("%7Btenant_id%7D", tenant_id);
+            let template = links[i].getAttribute('data-tenant_id-template');
+            links[i].href = template.replace("{tenant_id}", tenant_id).replace("%7Btenant_id%7D", tenant_id);
+        }
+
+
+
+        if (window.location.toString() !== theURL.href) {
+            window.history.replaceState({}, "", theURL.href);
         }
     }
 
     window.addEventListener("DOMContentLoaded", function () {
 
-        // const params = getHashParams();
-        // if ("tenant_id" in params) {
-        //     const tenant_id = params["tenant_id"];
-        // }
+        // Start by setting the data- attribute
+        const links = document.getElementsByClassName("btn-B2B");
+        for (let i = 0; i < links.length; i++) {
+            links[i].setAttribute('data-tenant_id-template', links[i].href);
+        }
 
         let theURL = new URL("https://dummy.com");
         theURL.search = window.location.search.substring(1);
-        const tenant_id = theURL.searchParams.get("tenant_id");
+        let tenant_id = theURL.searchParams.get("tenant_id");
 
-        replaceTenantId(tenant_id);
+        const tenantInput = document.querySelector("#tenant_id");
 
-        // const tenantInput = document.querySelector("#tenant_id");
-        // tenantInput.value = tenant_id;
-        // // Add Event Listeners for changes (After we set the initial value)
-        // tenantInput.addEventListener("change", showOnlyMatchedPortals);
-        // tenantInput.addEventListener("keyup", showOnlyMatchedPortals);
-        // tenantInput.focus({
-        //     preventScroll: true,
-        // });
+        if (tenant_id != null) {
+            tenantInput.value = tenant_id;
+        }
+
+        replaceTenantId();
+
+        // Add Event Listeners for changes (After we set the initial value)
+        tenantInput.addEventListener("change", replaceTenantId);
+        tenantInput.addEventListener("keyup", replaceTenantId);
+        tenantInput.focus({
+            preventScroll: true,
+        });
     }, false);
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -52,6 +52,7 @@
             {% if page.title contains "Portals" %}
             {% include quickfilter.html %}
             {% endif %}
+            {% include tenantid.html %}
 
         </div>
     </header>

--- a/add-in/css/style.css
+++ b/add-in/css/style.css
@@ -351,7 +351,7 @@ nav {
     color:#bcc7a7;
     font-style:italic
 }
-.btn-aka-ms{
+.btn-secondary{
     display:inline;
     padding:2px 6px;
     margin:4px 0px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -101,7 +101,7 @@
   font-style: italic;
 }
 
-.btn-aka-ms {
+.btn-secondary {
   display: inline;
   padding: 2px 6px;
   margin: 4px 0px;


### PR DESCRIPTION
As per #145, many portals are now B2B compatible, meaning that B2B guest users can access the portals directly. Managed service providers are increasingly using B2B guest users instead of having admin accounts in each customer environment.

Unfortunately, there are a variety of ways that this has been implemented: either as part of the URL (portal.azure.com, endpoint.microsoft.com), or with a `?tid=` / `?tenant=` / `?tenantId=` query value (security.microsoft.com, developer.microsoft.com, myaccess.microsoft.com), so implementing this involves using a templated URL, replaced with the tenant ID at runtime.

Once merged, users can use a link like https://msportals.io/?search=b2b&tenant_id=00000000-0000-0000-0000-000000000000 to access B2B-enabled portals, with the tenant ID pre-populated.

This is currently a **draft PR**, and before merging:

1. There's quite a few more portals to update. I just did a couple to demonstrate the use-case.
2. **There is a privacy issue:** the tenant_id value needs to be storable in a bookmark, but query parameters are leaked to web server logs and Google Analytics. Ideally we'd use a Location hash value (i.e., `#tenant_id=bla`, but hash is currently being used to anchor to specific headings. Either we need to amend/remove the anchor logic, or (have assurances that) query parameters are filtered from web server logs and Google Analytics.
3. We need to decide if there should be a tenant ID text box. Personally, I think most of us would be happy with just the tenant ID encoded in our bookmarks, which vastly reduces the complexity of implementing the template logic; but I could understand why people may want a user friendly text box as well.

Thoughts?

P.S. This PR also fixes a minor issue, that all secondary link buttons had the `btn-aka-ms` class.