### PR TITLE
Add Exchange Control Panel (Personal)

### DIFF
--- a/_data/portals/user.json
+++ b/_data/portals/user.json
@@ -191,6 +191,10 @@
           ]
         },
       {
+        "portalName": "Exchange Control Panel (Personal)",
+        "primaryURL": "https://outlook.office.com/ecp/"
+      },
+      {
         "portalName": "Microsoft Family Safety",
         "primaryURL": "https://account.microsoft.com/family/"
       },


### PR DESCRIPTION
"https://outlook.office.com/ecp/" gives a lot of access to administer Exchange as a standard user, for example, if you have delegations on distribution lists, which is not available elsewhere.