### PR TITLE
MyAnalytics become Viva Insights

### DIFF
--- a/_data/portals/user.json
+++ b/_data/portals/user.json
@@ -43,10 +43,6 @@
         "primaryURL": "https://dashboard.mileiq.com"
       },
       {
-        "portalName": "MyAnalytics",
-        "primaryURL": "https://myanalytics.microsoft.com"
-      },
-      {
         "portalName": "OneDrive",
         "primaryURL": "https://portal.office.com/onedrive"
       },


### PR DESCRIPTION
Since end of December 2022, MyAnalytics redirect to Viva Insights.

See here : [mya-retirement](https://learn.microsoft.com/en-us/viva/insights/personal/reference/mya-retirement)