### PR TITLE
endpoint.microsoft.com > intune.microsoft.com

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -61,19 +61,23 @@
         "primaryURL": "https://cqd.lync.com"
       },
       {
-        "portalName": "Microsoft Endpoint Manager Admin Console",
-        "primaryURL": "https://endpoint.microsoft.com",
+        "portalName": "Microsoft Intune Admin Center",
+        "primaryURL": "https://intune.microsoft.com",
         "secondaryURLs": [
           {
             "icon": "aka.ms",
             "url": "https://aka.ms/memac"
           },
           {
+            "icon": "Old 🔗",
+            "url": "https://endpoint.microsoft.com/"
+          },
+          {
             "icon": "B2B",
-            "url": "https://endpoint.microsoft.com/{tenant_id}"
+            "url": "https://intune.microsoft.com/{tenant_id}"
           }
         ],
-        "note": "Intune"
+        "note": "Endpoint Manager"
       },
       {
         "portalName": "Microsoft Endpoint Manager Admin Console",


### PR DESCRIPTION
Following this information : 

- https://learn.microsoft.com/en-us/mem/intune/fundamentals/whats-new#endpoint-manager-admin-center-is-renamed-to-intune-admin-center
- https://twitter.com/syst_and_deploy/status/1629497754190848000?s=20
- https://techcommunity.microsoft.com/t5/microsoft-365/confusion-on-the-various-endpoint-intune-microsoft-endpoint/m-p/3702773/highlight/true#M47525

*"Both https://endpoint.microsoft.com and https://intune.microsoft.com are the same portal. In the future https://endpoint.microsoft.com will be removed."*