### PR TITLE
Fix tenant_id=undefined

### DIFF
--- a/_includes/tenantid.html
+++ b/_includes/tenantid.html
@@ -22,7 +22,7 @@
             document.querySelector("#tenant_id_privacy_warning").style = "display:none";
         } else {
             theURL.search = window.location.search.substring(1);
-            theURL.searchParams.set("tenant_id", this.value);
+            theURL.searchParams.set("tenant_id", tenant_id);
             document.querySelector("#tenant_id_privacy_warning").style = "";
         }
 


### PR DESCRIPTION
Currently, if you bookmark msportals.io with `tenant_id=00000000-0000-0000-0000-000000000000`, on opening the bookmark this is replaced with `tenant_id=undefined`.

This is because I was using `this.value`, which is fine when replaceTenantId() is called from the onKey event, but not so fine on document load...