### PR TITLE
Replace Azure AD link with Microsoft Entra

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -259,12 +259,12 @@
         "note": "Preview"
       },
       {
-        "portalName": "Azure Active Directory admin center (Azure AD)",
-        "primaryURL": "https://aad.portal.azure.com",
+        "portalName": "Microsoft Entra Admin Center (Formerly Azure AD Admin Center)",
+        "primaryURL": "https://entra.microsoft.com",
         "secondaryURLs": [
           {
             "icon": "aka.ms",
-            "url": "https://aka.ms/azad"
+            "url": "https://aka.ms/MSEntraPortal"
           }
         ] 
       },

--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -261,6 +261,7 @@
       {
         "portalName": "Microsoft Entra Admin Center (Formerly Azure AD Admin Center)",
         "primaryURL": "https://entra.microsoft.com",
+        "note": "Identity Management"
         "secondaryURLs": [
           {
             "icon": "aka.ms",
@@ -514,11 +515,6 @@
         "portalName": "Microsoft Defender for Cloud (MDC)",
         "primaryURL": "https://portal.azure.com/#blade/Microsoft_Azure_Security/SecurityMenuBlade/0",
         "note": "Azure Security Center (ASC)"
-      },
-      {
-        "portalName": "Microsoft Entra admin center",
-        "primaryURL": "https://entra.microsoft.com",
-        "note": "Identity Management"
       },
       {
         "portalName": "Microsoft Secure Score",


### PR DESCRIPTION
As Microsoft has now rebranded Azure AD as Microsoft Entra (https://www.microsoft.com/en-gb/security/business/identity-access/azure-active-directory), the link needed to be replaced. Additionally the previous iteration of Microsoft Entra (security specific functionality has been moved into the same portal.