### PR TITLE
change search type from text to search

### DIFF
--- a/_includes/quickfilter.html
+++ b/_includes/quickfilter.html
@@ -1,6 +1,6 @@
 <form style="margin: 0; padding: 0; display: inline">
   <label for="search" style="display: none">Quick Filter:</label>
-  <input id="search" name="search" class="quickfilter" type="text" placeholder="Quick Filter" />
+  <input id="search" name="search" class="quickfilter" type="search" placeholder="Quick Filter" />
 </form>
 
 <script type="text/javascript">

--- a/add-in/index.html
+++ b/add-in/index.html
@@ -42,7 +42,7 @@
 						<li class="crumb"><a href="#About" id="linkAbout">About</a></li>
 					</ol>
 				</nav>
-				<form><input id="search" class="quickfilter" type="text" placeholder="Quick Filter"/></form>
+				<form><input id="search" class="quickfilter" type="search" placeholder="Quick Filter"/></form>
 			</div>
 		</header>
 		<div class="container">


### PR DESCRIPTION
Partially resolves #204, except Firefox doesn't (yet) provide a Clear button for `type="search"`

Draft WIP: let me see if there's a workaround for Firefox...