### PR TITLE
Azure Cosmos DB - Connection string authentication

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -293,6 +293,10 @@
         "primaryURL": "https://cosmos.azure.com"
       },
       {
+        "portalName": "Azure Cosmos DB - Connection string authentication",
+        "primaryURL": "https://cosmos.azure.com/sunset/"
+      },
+      {
         "portalName": "Azure Data Factory",
         "primaryURL": "https://adf.azure.com"
       },


### PR DESCRIPTION
Useful portal to connect to Cosmos DB using Connection string authentication instead Microsoft Entra.