### PR TITLE
fix: auth methods was pointing to deprecated url

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -332,8 +332,8 @@
     "groupName": "Azure IT Admin Portals - Sub Portal Links",
     "portals": [
       {
-        "portalName": "Azure Authentication methods",
-        "primaryURL": "https://aad.portal.azure.com/#blade/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/AdminAuthMethods/"
+        "portalName": "Microsoft Entra Authentication methods",
+        "primaryURL": "https://entra.microsoft.com/#view/Microsoft_AAD_IAM/AuthenticationMethodsMenuBlade/~/AdminAuthMethods/"
       },
       {
         "portalName": "Azure Backup Center",


### PR DESCRIPTION
I work on the team which owned aad.portal.azure.com. It isn't supported actively anymore.