### PR TITLE
Update admin.json

### DIFF
--- a/_data/portals/admin.json
+++ b/_data/portals/admin.json
@@ -31,7 +31,7 @@
       },
       {
         "portalName": "Exchange Admin Center (EAC)",
-        "primaryURL": "https://admin.cloud.microsoft/exchange/",
+        "primaryURL": "https://admin.cloud.microsoft/exchange#/",
         "secondaryURLs": [
           {
             "icon": "Old 🔗",


### PR DESCRIPTION
The Exchange Admin Center redirect seems to be malfunctioning, directing users to https://admin.cloud.microsoft/exchange/#/, results in an "Error: undefined."

Updated the URL to https://admin.cloud.microsoft/exchange#/ for accurate redirection.

https://techcommunity.microsoft.com/t5/exchange-team-blog/new-url-for-exchange-admin-center-eac-in-exchange-online/ba-p/4270023