### PR TITLE
Update us-govt.json

### DIFF
--- a/_data/portals/us-govt.json
+++ b/_data/portals/us-govt.json
@@ -101,11 +101,6 @@
         "note": "GCC High"
       },
       {
-        "portalName": "Security & Compliance",
-        "primaryURL": "https://scc.office365.us/homepage",
-        "note": "GCC High"
-      },
-      {
         "portalName": "Security",
         "primaryURL": "https://security.microsoft.us",
         "note": "GCC High"


### PR DESCRIPTION
Removed the link for GCCH security and compliance. It uses the shared purview.microsoft.us portal URL.

Verified this with a GCCH tenant, the purview.microsoft.us URL works correctly.

Edit: Just to clarify, the old URL directs to a portal which is depreciated. So the URL should be removed completely.