### PR TITLE
Add portal count to site header

### DIFF
--- a/3rdparty.md
+++ b/3rdparty.md
@@ -2,6 +2,8 @@
 layout: page
 title: 3rd Party Portals
 search: true
+portal_key: thirdparty
+portal_label: 3rd Party
 ---
 
 These portals are not Microsoft owned or controlled, but provide free and useful tools.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,26 @@
             </a>
             <h2>{{ site.description | default: "A comprehensive directory of all Microsoft portals in one place" }}</h2>
 
+            {% assign portal_count = 0 %}
+            {% for file in site.data.portals %}
+              {% unless file[0] == "PortalGroup.schema" or file[0] == "readme" %}
+                {% for group in file[1] %}
+                  {% assign portal_count = portal_count | plus: group.portals.size %}
+                {% endfor %}
+              {% endunless %}
+            {% endfor %}
+            <div class="portal-counter-row">
+              <span class="portal-count">{{ portal_count }} portals listed</span>
+              {% if page.portal_key %}
+                {% assign section_count = 0 %}
+                {% for group in site.data.portals.[page.portal_key] %}
+                  {% assign section_count = section_count | plus: group.portals.size %}
+                {% endfor %}
+                <span class="portal-count-divider">•</span>
+                <span class="portal-count">{{ section_count }} in {{ page.portal_label }}</span>
+              {% endif %}
+            </div>
+
             <section id="downloads">
                 {% if site.show_downloads %}
                 <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>

--- a/admin.md
+++ b/admin.md
@@ -2,6 +2,8 @@
 layout: page
 title: Administrator Portals
 search: true
+portal_key: admin
+portal_label: Admin
 ---
 Welcome to this community driven project to list all of Microsoft's portals in one place. [Submit an issue](https://github.com/adamfowlerit/msportals.io/issues) for any amendments to these links.
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -139,6 +139,30 @@
   }
 }
 
+.portal-counter-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0 12px;
+}
+
+.portal-count {
+  display: inline-block;
+  font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
+  font-size: 0.8em;
+  color: #b5e853;
+  border: 1px solid rgba(181, 232, 83, 0.35);
+  border-radius: 4px;
+  padding: 3px 12px;
+  background: rgba(181, 232, 83, 0.07);
+  letter-spacing: 0.03em;
+}
+
+.portal-count-divider {
+  color: rgba(181, 232, 83, 0.4);
+  font-size: 0.9em;
+}
+
 @media (prefers-color-scheme: light) {
   body {
     color: #111;
@@ -175,6 +199,16 @@
   .quickfilter {
     border-color: black;
     color: #333;
+  }
+
+  .portal-count {
+    color: #5a7a1a;
+    border-color: rgba(90, 122, 26, 0.4);
+    background: rgba(90, 122, 26, 0.07);
+  }
+
+  .portal-count-divider {
+    color: rgba(90, 122, 26, 0.4);
   }
 }
 .container {

--- a/china.md
+++ b/china.md
@@ -2,6 +2,8 @@
 layout: page
 title: China / 21Vianet Links
 search: true
+portal_key: china
+portal_label: China
 ---
 
 All the Microsoft China/21Vianet resources we could find in one place!

--- a/consumer.md
+++ b/consumer.md
@@ -2,6 +2,8 @@
 layout: page
 title: Consumer links
 search: true
+portal_key: consumer
+portal_label: Consumer
 ---
 
 All the Microsoft Consumer Portal links in one place! ***Work in Progress***

--- a/edu.md
+++ b/edu.md
@@ -2,6 +2,8 @@
 layout: page
 title: Education Links
 search: true
+portal_key: edu
+portal_label: Education
 ---
 
 All the Microsoft Education resources we could find in one place! Microsoft Education is for all sort of student education including K-12 Schools and Higher Education such as University/College.

--- a/licensing.md
+++ b/licensing.md
@@ -2,6 +2,8 @@
 layout: page
 title: Licensing Links
 search: true
+portal_key: licensing
+portal_label: Licensing
 ---
 
 All the Microsoft Licensing resources we could find in one place!

--- a/training.md
+++ b/training.md
@@ -2,6 +2,8 @@
 layout: page
 title: Training Links
 search: true
+portal_key: training
+portal_label: Training
 ---
 
 

--- a/userportals.md
+++ b/userportals.md
@@ -2,6 +2,8 @@
 layout: page
 title: User Portals
 search: true
+portal_key: user
+portal_label: End User
 ---
 
 These Microsoft portals are for end users.

--- a/usgovt.md
+++ b/usgovt.md
@@ -2,6 +2,8 @@
 layout: page
 title: Government Portals
 search: true
+portal_key: us-govt
+portal_label: US Government
 ---
 
 GCC, GCC High and DoD links to Microsoft Portals


### PR DESCRIPTION
 Closes #114                                                                                                             
                                         
  Added a portal count to the site header, computed at build time via Liquid.                                      
                                                                                                                        
  - Total count across all categories shown on every page
  - Per-category count shown when browsing a specific section (e.g. "208 in Admin")                                       
  - Both displayed side by side as styled badges in the header