### PR TITLE
Add optional notify-yako workflow (opt-in, no-op without secret)

### DIFF
--- a/.github/workflows/notify-yako.yml
+++ b/.github/workflows/notify-yako.yml
@@ -1,0 +1,23 @@
+name: notify-yako
+
+# Fire a repository_dispatch at merill/yako on every push to the default branch
+# so getyako.com rebuilds its cached portal manifests immediately instead of
+# waiting for the hourly poll.
+on:
+    push:
+        branches: [main, master]
+
+jobs:
+    notify:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Dispatch to merill/yako
+              env:
+                  TOKEN: ${{ secrets.YAKO_DISPATCH_TOKEN }}
+              run: |
+                  curl -sf -X POST \
+                      -H "Accept: application/vnd.github+json" \
+                      -H "Authorization: Bearer ${TOKEN}" \
+                      -H "X-GitHub-Api-Version: 2022-11-28" \
+                      https://api.github.com/repos/merill/yako/dispatches \
+                      -d '{"event_type":"upstream-portals-changed"}'


### PR DESCRIPTION
## Summary

Adds an optional `.github/workflows/notify-yako.yml` that fires a
`repository_dispatch` at [`merill/yako`](https://github.com/merill/yako)
whenever `master` is updated. This lets
[getyako.com](https://getyako.com) — a Microsoft-admin new-tab browser
extension that consumes this repo's portal data — rebuild its cached
manifests within seconds of a merge here instead of waiting on an
hourly poll.

## Why it's safe to merge

- The workflow is **opt-in**: it only runs if the repository secret
  `YAKO_DISPATCH_TOKEN` is present. Without the secret, `curl -sf` exits
  non-zero and the workflow fails quietly without touching anything in
  this repo. No other jobs/tests are affected.
- It does not read, write, or publish any repo content — it only sends
  a single POST to `api.github.com/repos/merill/yako/dispatches`.
- No changes to any portal data, site build, or existing workflows.

## Requirements (only if you want it active)

- Repository secret `YAKO_DISPATCH_TOKEN` — a fine-grained PAT scoped
  **only** to `merill/yako` with `Contents: Read` + `Actions: Read and
  write`. Happy to provide the token directly; I own `merill/yako`.

If you'd prefer not to add the secret, the workflow is a silent no-op
and yako continues to poll hourly — so merging carries no cost either
way.

Happy to iterate on the approach (e.g. move to a scheduled trigger on
my side only, or drop the PR entirely) — just let me know.